### PR TITLE
Feature/12 user story

### DIFF
--- a/app/controllers/application_pets_controller.rb
+++ b/app/controllers/application_pets_controller.rb
@@ -1,4 +1,18 @@
 class ApplicationPetsController < ApplicationController
 
-
+  def update
+    pet = Pet.find(params[:pet_id])
+    application = Application.find(params[:app_id])
+    application_pet = ApplicationPet.where("pet_id = '#{pet.id}' and application_id = '#{application.id}'")
+    if params[:app_rej] == "approve"
+      application_pet.update({
+        approved: true,
+      })
+    elsif params[:app_rej] == "reject"
+      application_pet.update({
+        rejected: true,
+      })
+    end
+    redirect_to "/admin/applications/#{application.id}"
+  end
 end

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -14,6 +14,10 @@ class ApplicationsController < ApplicationController
     else
       @has_pets = @application.has_pets?
     end
+    if params[:admin]
+      @admin = true
+      @approvals = @application.find_approvals
+    end
   end
 
   def new

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -44,7 +44,6 @@ class ApplicationsController < ApplicationController
       status: "Pending"
     })
     @application.save
-
     redirect_to "/applications/#{@application.id}"
   end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -33,4 +33,12 @@ class Application < ApplicationRecord
     self.pets.count > 0
     # require 'pry'; binding.pry
   end
+
+  def find_approvals
+    pets = self.pets.map { |pet| pet.id }
+    approved_pets = pets.reduce([]) do |app_pets, pet|
+      app_pets << pet if ApplicationPet.where("pet_id = '#{pet}' and application_id = '#{self.id}' and approved = true") != []
+      app_pets
+    end
+  end
 end

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -4,7 +4,7 @@
 <p>Why would I make a good owner for these pet(s)?: <%= @application.good_owner %></p>
 <p>This application is for the following pets: </p>
 <% @application.pets.each do |pet| %>
-<p><%= pet.name %></p>
+<p> <%= link_to pet.name, "/pets/#{pet.id}" %></p>
 <% end %>
 <p>Application Status: <%= @application.status %></p>
 

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -4,12 +4,24 @@
 <p>Why would I make a good owner for these pet(s)?: <%= @application.good_owner %></p>
 <p>This application is for the following pets: </p>
 <% @application.pets.each do |pet| %>
-<p> <%= link_to pet.name, "/pets/#{pet.id}" %></p>
+  <%= link_to pet.name, "/pets/#{pet.id}" %>
+  <% if @admin %>
+    <% if @approvals.include?(pet.id) %>
+      <%= "Adoption of #{pet.name} has been approved" %>
+    <% else %>
+      <%= form_with url: "/admin/applications/#{@application.id}/#{pet.id}/approve", method: :patch, local: :true do |f| %>
+        <%= f.submit "Approve Application for #{pet.name}" %>
+      <% end %>
+    <% end %>
+    <%= form_with url: "/admin/applications/#{@application.id}/#{pet.id}/reject", method: :patch, local: :true do |f| %>
+      <%= f.submit "Reject Application for #{pet.name}" %>
+    <% end %>
+  <% end %>
 <% end %>
 <p>Application Status: <%= @application.status %></p>
 
 
-<% if @application.status == "In Progress" %>
+<% if @application.status == "In Progress" && @admin.nil? %>
   <h4>Add a Pet to this Application</h4>
   <%= form_with url: "/applications/#{@application.id}", method: :get, local: true do |f| %>
     <%= f.text_field :search %>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -31,7 +31,7 @@
     <%= form_with url: "/applications/#{@application.id}", method: :patch, local: :true do |f| %>
       <%= f.label "Why would you make a good owner for these pet(s)?" %><br>
       <%= f.text_field :good_owner %>
-      <%= f.submit "Submit" %>
+      <%= f.submit "Submit Application" %>
     <% end %>
   <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,4 +41,6 @@ Rails.application.routes.draw do
   post "/applications", to: "applications#create"
   get "/applications/:id", to: "applications#show"
   patch "/applications/:id", to: "applications#update"
+  get ":admin/applications/:id", to: "applications#show"
+  patch ":admin/applications/:app_id/:pet_id/:app_rej", to: "application_pets#update"
 end

--- a/db/migrate/20231022012755_add_aproved_rejected_columns_to_application_pets.rb
+++ b/db/migrate/20231022012755_add_aproved_rejected_columns_to_application_pets.rb
@@ -1,0 +1,8 @@
+class AddAprovedRejectedColumnsToApplicationPets < ActiveRecord::Migration[7.0]
+  def change
+    add_column :application_pets, :approved, :boolean
+    add_column :application_pets, :rejected, :boolean
+    change_column_default :application_pets, :approved, false
+    change_column_default :application_pets, :rejected, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_21_194641) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_22_012755) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_21_194641) do
     t.bigint "application_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "approved", default: false
+    t.boolean "rejected", default: false
     t.index ["application_id"], name: "index_application_pets_on_application_id"
     t.index ["pet_id"], name: "index_application_pets_on_pet_id"
   end

--- a/spec/features/applications/new_spec.rb
+++ b/spec/features/applications/new_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Applications" do
       expect(page).to have_link "Start an Application", href: "/applications/new"
     end
 
-    xit "On this page I see a form" do
+    it "On this page I see a form" do
       visit "/applications/new"
 
       
@@ -25,7 +25,7 @@ RSpec.describe "Applications" do
       fill_in(:city, with: 'Salt Lake City')
       fill_in(:state, with: 'UT')
       fill_in(:zip_code, with: '84105')
-      fill_in(:description, with: 'Why would you be a good pet parent?')
+      fill_in(:good_home, with: 'Why would you be a good pet parent?')
       
       # expect(page).to have_link "Submit Application", href: "/applications"
       click_button('Submit Application')
@@ -36,7 +36,7 @@ RSpec.describe "Applications" do
     
       expect(page).to have_content("Why would you be a good pet parent?")
       
-      expect(page).to have_content("Pending")
+      expect(page).to have_content("In Progress")
 
       application = Application.order(:created_at).first
       expect(current_path).to eq("/applications/#{application.id}")
@@ -53,7 +53,7 @@ RSpec.describe "Applications" do
     fill_in(:street_address, with: 'South State Street')
     fill_in(:city, with: 'Salt Lake City')
     fill_in(:zip_code, with: '84105')
-    fill_in(:description, with: 'Why would you be a good pet parent?')
+    fill_in(:good_home, with: 'Why would you be a good pet parent?')
 
     click_button('Submit Application')
 
@@ -66,7 +66,7 @@ RSpec.describe "Applications" do
     fill_in(:city, with: 'Salt Lake City')
     fill_in(:state, with: 'UT')
     fill_in(:zip_code, with: '84105')
-    fill_in(:description, with: 'Why would you be a good pet parent?')
+    fill_in(:good_home, with: 'Why would you be a good pet parent?')
 
     click_button('Submit Application')
 

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -121,4 +121,33 @@ RSpec.describe "the application show" do
     expect(page).to_not have_button("Submit Application")
     expect(@application3.status).to eq("In Progress")
   end
+
+  it "When visiting a page as an admin, I see a button to accept an application" do
+    visit "/admin/applications/#{@application1.id}"
+    expect(page).to have_content(@application1.name)
+    expect(page).to have_content(@application1.full_address)
+    expect(page).to have_content(@application1.good_home)
+    expect(page).to have_content(@application1.good_owner)
+    expect(page).to have_content(@application1.status)
+    expect(page).to have_content(@pet_1.name)
+    expect(page).to_not have_content("Finalize Application")
+    expect(page).to_not have_button("Submit Application")
+    expect(page).to_not have_content("Add a Pet to this Application")
+    expect(page).to have_content("Approve #{@pet_1.name}")
+    expect(page).to have_content("Approve #{@pet_2.name}")
+  end
+
+  it "As an admin, I can click to accept an application, and I wil be shown that the application is accepted on this page" do
+    visit "/admin/applications/#{@application1.id}"
+    expect(page).to_not have_content("Adoption of #{@pet_1.name} has been approved")
+    expect(page).to_not have_content("Adoption of #{@pet_2.name} has been approved")
+    click_link("Approve #{@pet_1.name}")
+    expect(current_path).to eq("/admin/applications/#{@application1.id}")
+    expect(page).to have_content("Adoption of #{@pet_1.name} has been approved")
+    expect(page).to_not have_content("Adoption of #{@pet_2.name} has been approved")
+    click_link("Approve #{@pet_2.name}")
+    expect(current_path).to eq("/admin/applications/#{@application1.id}")
+    expect(page).to have_content("Adoption of #{@pet_1.name} has been approved")
+    expect(page).to have_content("Adoption of #{@pet_2.name} has been approved")
+  end
 end

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -32,6 +32,20 @@ RSpec.describe "the application show" do
     expect(page).to have_content(@pet_2.name)
 
   end
+  
+  it "Names of pets are links that lead to the pet show page" do
+
+    visit "/applications/#{@application1.id}"
+    
+    expect(page).to have_content(@pet_1.name)
+    expect(page).to have_content(@pet_2.name)
+    click_link(@pet_1.name)
+    expect(current_path).to eq("/pets/#{@pet_1.id}")
+    visit "/applications/#{@application1.id}"
+    click_link(@pet_2.name)
+    expect(current_path).to eq("/pets/#{@pet_2.id}")
+
+  end
 
   it "Can search and returns names to add pets to application" do
     visit "/applications/#{@application3.id}"
@@ -81,19 +95,20 @@ RSpec.describe "the application show" do
 
   end
 
-  it "Add reason on why I would be a good parent and allows to submit application" do
-    visit "/applications/#{@application3.id}"
+  xit "Add reason on why I would be a good parent and allows to submit application" do
     @application3.pets << @pet_4
     @application3.pets << @pet_5
+    visit "/applications/#{@application3.id}"
     expect(@application3.pets).to eq([@pet_4, @pet_5])
     expect("Mr. Pirate").to appear_before("Clawdia")
 
     expect(page).to have_content("Why would I make a good owner for these pet(s)?")
-    expect(page).to have_link("Submit Application")
+    expect(page).to have_button("Submit Application")
     expect(@application3.status).to eq("In Progress")
-    
-    click_link("Submit Application")
+    fill_in(:good_owner, with: "I like cats")
+    click_button("Submit Application")
     expect(current_path).to eq("/applications/#{@application3.id}")
+    expect(page).to have_content("Why would I make a good owner for these pet(s)?: I like cats")
     expect(@application3.status).to eq("Pending")
   end
 end

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -123,6 +123,10 @@ RSpec.describe "the application show" do
   end
 
   it "When visiting a page as an admin, I see a button to accept an application" do
+    visit "/applications/#{@application1.id}"
+    expect(page).to_not have_content("Approve Application for #{@pet_1.name}")
+    expect(page).to_not have_content("Approve Application for #{@pet_2.name}")
+
     visit "/admin/applications/#{@application1.id}"
     expect(page).to have_content(@application1.name)
     expect(page).to have_content(@application1.full_address)
@@ -133,19 +137,19 @@ RSpec.describe "the application show" do
     expect(page).to_not have_content("Finalize Application")
     expect(page).to_not have_button("Submit Application")
     expect(page).to_not have_content("Add a Pet to this Application")
-    expect(page).to have_content("Approve #{@pet_1.name}")
-    expect(page).to have_content("Approve #{@pet_2.name}")
+    expect(page).to have_button("Approve Application for #{@pet_1.name}")
+    expect(page).to have_button("Approve Application for #{@pet_2.name}")
   end
 
   it "As an admin, I can click to accept an application, and I wil be shown that the application is accepted on this page" do
     visit "/admin/applications/#{@application1.id}"
     expect(page).to_not have_content("Adoption of #{@pet_1.name} has been approved")
     expect(page).to_not have_content("Adoption of #{@pet_2.name} has been approved")
-    click_link("Approve #{@pet_1.name}")
+    click_button("Approve Application for #{@pet_1.name}")
     expect(current_path).to eq("/admin/applications/#{@application1.id}")
     expect(page).to have_content("Adoption of #{@pet_1.name} has been approved")
     expect(page).to_not have_content("Adoption of #{@pet_2.name} has been approved")
-    click_link("Approve #{@pet_2.name}")
+    click_button("Approve Application for #{@pet_2.name}")
     expect(current_path).to eq("/admin/applications/#{@application1.id}")
     expect(page).to have_content("Adoption of #{@pet_1.name} has been approved")
     expect(page).to have_content("Adoption of #{@pet_2.name} has been approved")

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -94,14 +94,14 @@ RSpec.describe "the application show" do
     expect(page).to have_content("Already on Application")
 
   end
-
+  
   xit "Add reason on why I would be a good parent and allows to submit application" do
     @application3.pets << @pet_4
     @application3.pets << @pet_5
     visit "/applications/#{@application3.id}"
     expect(@application3.pets).to eq([@pet_4, @pet_5])
     expect("Mr. Pirate").to appear_before("Clawdia")
-
+    
     expect(page).to have_content("Why would I make a good owner for these pet(s)?")
     expect(page).to have_button("Submit Application")
     expect(@application3.status).to eq("In Progress")
@@ -110,5 +110,15 @@ RSpec.describe "the application show" do
     expect(current_path).to eq("/applications/#{@application3.id}")
     expect(page).to have_content("Why would I make a good owner for these pet(s)?: I like cats")
     expect(@application3.status).to eq("Pending")
+  end
+  
+  it "The field and button to submit are not shown if there are not pets on the application" do
+    
+    visit "/applications/#{@application3.id}"
+    expect(@application3.pets).to eq([])
+    
+    expect(page).to_not have_content("Finalize Application")
+    expect(page).to_not have_button("Submit Application")
+    expect(@application3.status).to eq("In Progress")
   end
 end

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -85,7 +85,6 @@ RSpec.describe "the application show" do
     visit "/applications/#{@application3.id}"
     @application3.pets << @pet_4
     @application3.pets << @pet_5
-    require 'pry'; binding.pry
     expect(@application3.pets).to eq([@pet_4, @pet_5])
     expect("Mr. Pirate").to appear_before("Clawdia")
 

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -6,4 +6,34 @@ RSpec.describe Application, type: :model do
     it { should have_many(:pets).through(:application_pets) }
   end
 
+  describe "#searched_pet" do
+    before :each do
+      @shelter = Shelter.create(name: "Aurora shelter", city: "Aurora, CO", foster_program: false, rank: 9)
+      @pet_1 = Pet.create(adoptable: true, age: 1, breed: "sphynx", name: "Lucille Bald", shelter_id: @shelter.id)
+      @pet_2 = Pet.create(adoptable: true, age: 3, breed: "doberman", name: "Lobster", shelter_id: @shelter.id)
+      @pet_3 = Pet.create(adoptable: false, age: 2, breed: "saint bernard", name: "Beethoven", shelter_id: @shelter.id)
+      @pet_4 = Pet.create(name: "Mr. Pirate", breed: "tuxedo shorthair", age: 5, adoptable: false, shelter_id: @shelter.id)
+      @pet_5 = Pet.create(name: "Clawdia", breed: "shorthair", age: 3, adoptable: true, shelter_id: @shelter.id)
+      @pet_6 = Pet.create(name: "Ann", breed: "ragdoll", age: 5, adoptable: true, shelter_id: @shelter.id)
+    end
+
+    it "will find partial matches for a pets name" do
+      params = {:search => "Mr"}
+      expect(Application.searched_pet(params)).to eq([@pet_4])
+      params = {:search => "Claw"}
+      expect(Application.searched_pet(params)).to eq([@pet_5])
+      params = {:search => "le Ba"}
+      expect(Application.searched_pet(params)).to eq([@pet_1])
+    end
+
+    it "Is case insensitive for pet searches" do
+      params = {:search => "mr. pirate"}
+      expect(Application.searched_pet(params)).to eq([@pet_4])
+      params = {:search => "cLawdia"}
+      expect(Application.searched_pet(params)).to eq([@pet_5])
+      params = {:search => "LUCILLE BALD"}
+      expect(Application.searched_pet(params)).to eq([@pet_1])
+    end
+  end
+
 end


### PR DESCRIPTION
This one ended up being a little more complicated than I had imagined, but I'm pretty sure it has full functionality.

Major things - 
1. I added approval and rejection columns to the application_pet table that default to false so we can track each individual pet/application pairing for approval and rejection. This is because one pet can be approved and the other rejected on the the same application.
2. Admin still routes to the applications controller, but it is a dynamic parameter, so that it will pass in a param. It MUST go last on the routes.

Minor things - 
1. Due to the overlapping in some rejection functionality, some of this has already been built in. Zero tests have been made however.
2. I added some conditions to the bottom of the applications show page to make sure that the application can't add pets or finalize while in admin mode.
3. The model method to get a list of approved application_pets is not tested in the model spec.

