### PR TITLE
Replace link to adopt a pet with a button to better satisfy User Story 5

### DIFF
--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -33,8 +33,10 @@
   <% if @searched != nil %>
     <%= "Results:" %> <br>
     <% @searched.each do |pet| %>
+      
       <%= pet.name %> 
-      <%= link_to "Adopt this Pet", :adopt => "#{pet.id}" %> <br>
+      <%= button_to "Adopt this Pet", { action: "show" }, params: {:adopt => "#{pet.id}"}, method: :get , remote: true %>
+
     <% end %>
   <% end %>
 

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -74,8 +74,8 @@ RSpec.describe "the application show" do
     click_button("Search")
     expect("Add a Pet to this Application").to appear_before("Clawdia")
     expect("Clawdia").to appear_before("Adopt this Pet")
-    # click_button("Adopt this Pet")
-    click_link("Adopt this Pet")
+    click_button("Adopt this Pet")
+    # click_link("Adopt this Pet")
     expect(current_path).to eq("/applications/#{@application3.id}")
     expect("Clawdia").to appear_before("Add a Pet to this Application")
   end
@@ -85,12 +85,12 @@ RSpec.describe "the application show" do
     expect(page).to_not have_content("Already on Application")
     fill_in(:search, with: "Clawdia")
     click_button("Search")
-    # click_button("Adopt this Pet")
-    click_link("Adopt this Pet")
+    click_button("Adopt this Pet")
+    # click_link("Adopt this Pet")
     expect(page).to_not have_content("Already on Application")
     fill_in(:search, with: "Clawdia")
     click_button("Search")
-    click_link("Adopt this Pet")
+    click_button("Adopt this Pet")
     expect(page).to have_content("Already on Application")
 
   end
@@ -176,6 +176,45 @@ RSpec.describe "the application show" do
     click_button("Reject Application for #{@pet_2.name}")
     expect(current_path).to eq("/admin/applications/#{@application1.id}")
     expect(page).to have_content("Adoption of #{@pet_1.name} has been rejected")
+    expect(page).to have_content("Adoption of #{@pet_2.name} has been rejected")
+  end
+
+  it "Accepting a pet on one application will not affect it's status on other applications" do
+    visit "/admin/applications/#{@application2.id}"
+    expect(page).to have_button("Approve Application for #{@pet_2.name}")
+    expect(page).to have_button("Reject Application for #{@pet_2.name}")
+    expect(page).to_not have_content("Adoption of #{@pet_2.name} has been approved")
+    expect(page).to_not have_content("Adoption of #{@pet_2.name} has been rejected")
+    visit "/admin/applications/#{@application1.id}"
+    click_button("Approve Application for #{@pet_2.name}")
+    visit "/admin/applications/#{@application2.id}"
+    expect(page).to have_button("Approve Application for #{@pet_2.name}")
+    expect(page).to have_button("Reject Application for #{@pet_2.name}")
+    expect(page).to_not have_content("Adoption of #{@pet_2.name} has been approved")
+    expect(page).to_not have_content("Adoption of #{@pet_2.name} has been rejected")
+    click_button("Approve Application for #{@pet_2.name}")
+    expect(page).to_not have_button("Approve Application for #{@pet_2.name}")
+    expect(page).to_not have_button("Reject Application for #{@pet_2.name}")
+    expect(page).to have_content("Adoption of #{@pet_2.name} has been approved")
+    expect(page).to_not have_content("Adoption of #{@pet_2.name} has been rejected")
+    visit "/admin/applications/#{@application1.id}"
+    expect(page).to have_content("Adoption of #{@pet_2.name} has been approved")
+  end
+
+  it "Rejcting a pet on one application will not affect it's status on other applications" do
+    visit "/admin/applications/#{@application1.id}"
+    click_button("Reject Application for #{@pet_2.name}")
+    visit "/admin/applications/#{@application2.id}"
+    expect(page).to have_button("Approve Application for #{@pet_2.name}")
+    expect(page).to have_button("Reject Application for #{@pet_2.name}")
+    expect(page).to_not have_content("Adoption of #{@pet_2.name} has been approved")
+    expect(page).to_not have_content("Adoption of #{@pet_2.name} has been rejected")
+    click_button("Approve Application for #{@pet_2.name}")
+    expect(page).to_not have_button("Approve Application for #{@pet_2.name}")
+    expect(page).to_not have_button("Reject Application for #{@pet_2.name}")
+    expect(page).to have_content("Adoption of #{@pet_2.name} has been approved")
+    expect(page).to_not have_content("Adoption of #{@pet_2.name} has been rejected")
+    visit "/admin/applications/#{@application1.id}"
     expect(page).to have_content("Adoption of #{@pet_2.name} has been rejected")
   end
 end


### PR DESCRIPTION
On the application show page, a link previously represented the action to add searched pets to an application. This link has been replaced with a button to better satisfy User Story 5.

Testing was also added for User story 14, although the functionality was already present