### PR TITLE
Feature/18 user story

### DIFF
--- a/app/controllers/application_pets_controller.rb
+++ b/app/controllers/application_pets_controller.rb
@@ -14,6 +14,7 @@ class ApplicationPetsController < ApplicationController
           status: "Approved"
         })
         Pet.update_adoptable(application.id)
+        Pet.update_rejected_apps(application)
       end
     elsif params[:app_rej] == "reject"
       application_pet.update({

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -22,4 +22,18 @@ class Pet < ApplicationRecord
       })
     end
   end
+
+  def self.update_rejected_apps(application)
+    adopted_pets = application.pets
+    adopted_pets.each do |pet|
+      app_pets = ApplicationPet.where("pet_id = ?", pet.id)
+      app_pets.each do |app_pet|
+        unless app_pet.application_id == application.id
+          app_pet.update({
+            approved: false
+          })
+        end
+      end
+    end
+  end
 end

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -11,8 +11,12 @@
     <% elsif @rejections.include?(pet.id)%>
       <%= "Adoption of #{pet.name} has been rejected" %> <br>
     <% else %>
-      <%= form_with url: "/admin/applications/#{@application.id}/#{pet.id}/approve", method: :patch, local: :true do |f| %>
-        <%= f.submit "Approve Application for #{pet.name}" %>
+      <% if pet.adoptable%>
+        <%= form_with url: "/admin/applications/#{@application.id}/#{pet.id}/approve", method: :patch, local: :true do |f| %>
+          <%= f.submit "Approve Application for #{pet.name}" %>
+        <% end %>
+      <% else %>
+        <%= "#{pet.name} has been approved for adoption on another application" %>
       <% end %>
       <%= form_with url: "/admin/applications/#{@application.id}/#{pet.id}/reject", method: :patch, local: :true do |f| %>
         <%= f.submit "Reject Application for #{pet.name}" %>

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -263,4 +263,28 @@ RSpec.describe "the application show" do
     expect(current_path).to eq("/pets/#{@pet_1.id}")
     expect(page).to have_content("Adoptable: false")
   end
+
+  it "A pet that has been approved for adoption cannot be approved on other applications (and is communicated)" do
+    visit "/admin/applications/#{@application1.id}"
+    click_button("Approve Application for #{@pet_1.name}")
+    click_button("Approve Application for #{@pet_2.name}")
+    visit "/admin/applications/#{@application2.id}"
+    expect(page).to_not have_content("Approve Application for #{@pet_1.name}")
+    expect(page).to have_content("#{@pet_1.name} has been approved for adoption on another application")
+    expect(page).to have_content("Reject Application for #{@pet_1.name}")
+  end
+
+  it "Once a pet is on an application that is fully approved it will have approval removed from all other application" do
+    visit "/admin/applications/#{@application1.id}"
+    click_button("Approve Application for #{@pet_2.name}")
+    visit "/admin/applications/#{@application2.id}"
+    expect(page).to_not have_content("#{@pet_1.name} has been approved for adoption on another application")
+    click_button("Approve Application for #{@pet_2.name}")
+    visit "/admin/applications/#{@application1.id}"
+    click_button("Approve Application for #{@pet_1.name}")
+    visit "/admin/applications/#{@application2.id}"
+    expect(page).to have_content("#{@pet_1.name} has been approved for adoption on another application")
+    expect(page).to_not have_content("Approve Application for #{@pet_1.name}")
+    expect(page).to have_content("Reject Application for #{@pet_1.name}")
+  end
 end

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -265,16 +265,40 @@ RSpec.describe "the application show" do
   end
 
   it "A pet that has been approved for adoption cannot be approved on other applications (and is communicated)" do
-    visit "/admin/applications/#{@application1.id}"
-    click_button("Approve Application for #{@pet_1.name}")
-    click_button("Approve Application for #{@pet_2.name}")
-    visit "/admin/applications/#{@application2.id}"
-    expect(page).to_not have_content("Approve Application for #{@pet_1.name}")
-    expect(page).to have_content("#{@pet_1.name} has been approved for adoption on another application")
-    expect(page).to have_content("Reject Application for #{@pet_1.name}")
+    shelter = Shelter.create(name: "Aurora shelter", city: "Aurora, CO", foster_program: false, rank: 9)
+    application1 = Application.create!(name: "Mike", full_address: "9999 Street Road, Denver, CO 80231", good_home: "Gimme", good_owner: "one eyed cats!!", status: "Pending")
+    application2 = Application.create!(name: "Eric", full_address: "888 Road Street, Salt Lake City, UT 88231", good_home: "5 solid meals a day", good_owner: "I woudln't", status: "Pending")
+    pet_1 = Pet.create(adoptable: true, age: 1, breed: "sphynx", name: "Lucille Bald", shelter_id: shelter.id)
+    pet_2 = Pet.create(adoptable: true, age: 3, breed: "doberman", name: "Lobster", shelter_id: shelter.id)
+    pet_3 = Pet.create(adoptable: true, age: 2, breed: "saint bernard", name: "Beethoven", shelter_id: shelter.id)
+    application1.pets << pet_1 
+    application1.pets << pet_2 
+    application2.pets << pet_2 
+    application2.pets << pet_3
+    
+    visit "/admin/applications/#{application2.id}"
+    expect(page).to have_button("Approve Application for #{pet_2.name}")
+    visit "/admin/applications/#{application1.id}"
+    click_button("Approve Application for #{pet_1.name}")
+    click_button("Approve Application for #{pet_2.name}")
+    visit "/admin/applications/#{application2.id}"
+    expect(page).to_not have_button("Approve Application for #{pet_2.name}")
+    expect(page).to have_content("#{pet_2.name} has been approved for adoption on another application")
+    expect(page).to have_button("Reject Application for #{pet_2.name}")
   end
-
+  
   it "Once a pet is on an application that is fully approved it will have approval removed from all other application" do
+    shelter = Shelter.create(name: "Aurora shelter", city: "Aurora, CO", foster_program: false, rank: 9)
+    application1 = Application.create!(name: "Mike", full_address: "9999 Street Road, Denver, CO 80231", good_home: "Gimme", good_owner: "one eyed cats!!", status: "Pending")
+    application2 = Application.create!(name: "Eric", full_address: "888 Road Street, Salt Lake City, UT 88231", good_home: "5 solid meals a day", good_owner: "I woudln't", status: "Pending")
+    pet_1 = Pet.create(adoptable: true, age: 1, breed: "sphynx", name: "Lucille Bald", shelter_id: shelter.id)
+    pet_2 = Pet.create(adoptable: true, age: 3, breed: "doberman", name: "Lobster", shelter_id: shelter.id)
+    pet_3 = Pet.create(adoptable: true, age: 2, breed: "saint bernard", name: "Beethoven", shelter_id: shelter.id)
+    application1.pets << pet_1 
+    application1.pets << pet_2 
+    application2.pets << pet_2 
+    application2.pets << pet_3
+
     visit "/admin/applications/#{@application1.id}"
     click_button("Approve Application for #{@pet_2.name}")
     visit "/admin/applications/#{@application2.id}"
@@ -283,8 +307,8 @@ RSpec.describe "the application show" do
     visit "/admin/applications/#{@application1.id}"
     click_button("Approve Application for #{@pet_1.name}")
     visit "/admin/applications/#{@application2.id}"
-    expect(page).to have_content("#{@pet_1.name} has been approved for adoption on another application")
-    expect(page).to_not have_content("Approve Application for #{@pet_1.name}")
-    expect(page).to have_content("Reject Application for #{@pet_1.name}")
+    expect(page).to have_content("#{@pet_2.name} has been approved for adoption on another application")
+    expect(page).to_not have_button("Approve Application for #{@pet_2.name}")
+    expect(page).to have_button("Reject Application for #{@pet_2.name}")
   end
 end


### PR DESCRIPTION
This satisfies User Story 18. It doesn't autoreject all applications where the pets have been approved on other applications, but it does flip the status of their approval on the other applications and block approval (so that the only course of action is to eventually reject the application).